### PR TITLE
feat: Expose `details` parameter to `onRegionChangeComplete`

### DIFF
--- a/lib/ClusteredMapView.js
+++ b/lib/ClusteredMapView.js
@@ -59,9 +59,10 @@ const ClusteredMapView = forwardRef(
     const [clusterChildren, updateClusterChildren] = useState(null);
     const mapRef = useRef();
 
-    const propsChildren = useMemo(() => React.Children.toArray(children), [
-      children,
-    ]);
+    const propsChildren = useMemo(
+      () => React.Children.toArray(children),
+      [children]
+    );
 
     useEffect(() => {
       const rawData = [];
@@ -128,7 +129,7 @@ const ClusteredMapView = forwardRef(
       }
     }, [isSpiderfier, markers]);
 
-    const _onRegionChangeComplete = (region) => {
+    const _onRegionChangeComplete = (region, details) => {
       if (superCluster && region) {
         const bBox = calculateBBox(region);
         const zoom = returnMapZoom(region, bBox, minZoom);
@@ -143,10 +144,10 @@ const ClusteredMapView = forwardRef(
         }
         updateMarkers(markers);
         onMarkersChange(markers);
-        onRegionChangeComplete(region, markers);
+        onRegionChangeComplete(region, details, markers);
         updateRegion(region);
       } else {
-        onRegionChangeComplete(region);
+        onRegionChangeComplete(region, details);
       }
     };
 


### PR DESCRIPTION
This commit updates the `onRegionChangeComplete` method signature so that it expose the `details` parameter so upstream apps can use the `details.isGesture` prop.